### PR TITLE
v2.1.22

### DIFF
--- a/safeheron/api/transaction_api.go
+++ b/safeheron/api/transaction_api.go
@@ -36,6 +36,9 @@ type TransactionsRequest struct {
 	FeeCoinKey                 string               `json:"feeCoinKey"`
 	ReplaceTxHash              string               `json:"replaceTxHash"`
 	CustomerRefId              string               `json:"customerRefId"`
+	Nonce                      string               `json:"nonce"`
+	ReplacedTxKey              string               `json:"replacedTxKey"`
+	ReplacedCustomerRefId      string               `json:"replacedCustomerRefId"`
 	CustomerExt1               string               `json:"customerExt1"`
 	CustomerExt2               string               `json:"customerExt2"`
 	AmlLock                    string               `json:"amlLock"`
@@ -251,6 +254,9 @@ type OneTransactionsResponse struct {
 	FeeCoinKey                 string                `json:"feeCoinKey"`
 	ReplaceTxHash              string                `json:"replaceTxHash"`
 	CustomerRefId              string                `json:"customerRefId"`
+	Nonce                      string                `json:"nonce"`
+	ReplacedTxKey              string                `json:"replacedTxKey"`
+	ReplacedCustomerRefId      string                `json:"replacedCustomerRefId"`
 	CustomerExt1               string                `json:"customerExt1"`
 	CustomerExt2               string                `json:"customerExt2"`
 	AmlLock                    string                `json:"amlLock"`

--- a/safeheron/cosigner/cosigner_converter.go
+++ b/safeheron/cosigner/cosigner_converter.go
@@ -17,7 +17,7 @@ type CoSignerConverter struct {
 	Config CoSignerConfig
 }
 
-func (c *CoSignerConfig) GetApprovalCallbackServicePrivateKey() string {
+func (c *CoSignerConfig) getApprovalCallbackServicePrivateKey() string {
 	//Supports both approvalCallbackServicePrivateKey and bizPrivKey
 	if c.ApprovalCallbackServicePrivateKey == "" {
 		c.ApprovalCallbackServicePrivateKey = c.BizPrivKey
@@ -25,7 +25,7 @@ func (c *CoSignerConfig) GetApprovalCallbackServicePrivateKey() string {
 	return c.ApprovalCallbackServicePrivateKey
 }
 
-func (c *CoSignerConfig) GetCoSignerPubKey() string {
+func (c *CoSignerConfig) getCoSignerPubKey() string {
 	//Supports both coSignerPubKey and apiPublKey
 	if c.CoSignerPubKey == "" {
 		c.CoSignerPubKey = c.ApiPubKey
@@ -63,16 +63,16 @@ func (c *CoSignerConverter) RequestConvert(d CoSignerCallBack) (string, error) {
 		"bizContent": d.BizContent,
 	}
 	// Verify sign
-	verifyRet := utils.VerifySignWithRSA(serializeParams(responseStringMap), d.Sig, c.Config.GetCoSignerPubKey())
+	verifyRet := utils.VerifySignWithRSA(serializeParams(responseStringMap), d.Sig, c.Config.getCoSignerPubKey())
 	if !verifyRet {
 		return "", errors.New("CoSignerCallBack signature verification failed")
 	}
 	// Use your RSA private key to decrypt response's aesKey and aesIv
 	var plaintext []byte
 	if d.RsaType == utils.ECB_OAEP {
-		plaintext, _ = utils.DecryptWithOAEP(d.Key, c.Config.GetApprovalCallbackServicePrivateKey())
+		plaintext, _ = utils.DecryptWithOAEP(d.Key, c.Config.getApprovalCallbackServicePrivateKey())
 	} else {
-		plaintext, _ = utils.DecryptWithRSA(d.Key, c.Config.GetApprovalCallbackServicePrivateKey())
+		plaintext, _ = utils.DecryptWithRSA(d.Key, c.Config.getApprovalCallbackServicePrivateKey())
 	}
 	resAesKey := plaintext[:32]
 	resAesIv := plaintext[32:]
@@ -94,7 +94,7 @@ func (c *CoSignerConverter) RequestV3Convert(d CoSignerCallBackV3) (string, erro
 		"bizContent": d.BizContent,
 	}
 	// Verify sign
-	verifyRet := utils.VerifySignWithRSAPSS(serializeParams(responseStringMap), d.Sig, c.Config.GetCoSignerPubKey())
+	verifyRet := utils.VerifySignWithRSAPSS(serializeParams(responseStringMap), d.Sig, c.Config.getCoSignerPubKey())
 	if !verifyRet {
 		return "", errors.New("CoSignerCallBack signature verification failed")
 	}
@@ -116,7 +116,7 @@ func (c *CoSignerConverter) ResponseV3Converter(d any) (map[string]string, error
 	}
 
 	// Sign the request data with your Approval Callback Service's private Key
-	signature, err := utils.SignParamsWithRSAPSS(serializeParams(params), c.Config.GetApprovalCallbackServicePrivateKey())
+	signature, err := utils.SignParamsWithRSAPSS(serializeParams(params), c.Config.getApprovalCallbackServicePrivateKey())
 	if err != nil {
 		return nil, err
 	}
@@ -158,14 +158,14 @@ func (c *CoSignerConverter) ResponseConverter(d any) (map[string]string, error) 
 	}
 
 	// Use Safeheron RSA public key to encrypt request's aesKey and aesIv
-	encryptedKeyAndIv, err := utils.EncryptWithRSA(append(aesKey, aesIv...), c.Config.GetCoSignerPubKey())
+	encryptedKeyAndIv, err := utils.EncryptWithRSA(append(aesKey, aesIv...), c.Config.getCoSignerPubKey())
 	if err != nil {
 		return nil, err
 	}
 	params["key"] = encryptedKeyAndIv
 
 	// Sign the request data with your RSA private key
-	signature, err := utils.SignParamsWithRSA(serializeParams(params), c.Config.GetApprovalCallbackServicePrivateKey())
+	signature, err := utils.SignParamsWithRSA(serializeParams(params), c.Config.getApprovalCallbackServicePrivateKey())
 	if err != nil {
 		return nil, err
 	}
@@ -196,14 +196,14 @@ func (c *CoSignerConverter) ResponseConverterWithNewCryptoType(d any) (map[strin
 	}
 
 	// Use Safeheron RSA public key to encrypt request's aesKey and aesIv
-	encryptedKeyAndIv, err := utils.EncryptWithOAEP(append(aesKey, aesIv...), c.Config.GetCoSignerPubKey())
+	encryptedKeyAndIv, err := utils.EncryptWithOAEP(append(aesKey, aesIv...), c.Config.getCoSignerPubKey())
 	if err != nil {
 		return nil, err
 	}
 	params["key"] = encryptedKeyAndIv
 
 	// Sign the request data with your RSA private key
-	signature, err := utils.SignParamsWithRSA(serializeParams(params), c.Config.GetApprovalCallbackServicePrivateKey())
+	signature, err := utils.SignParamsWithRSA(serializeParams(params), c.Config.getApprovalCallbackServicePrivateKey())
 	if err != nil {
 		return nil, err
 	}

--- a/safeheron/cosigner/cosigner_converter.go
+++ b/safeheron/cosigner/cosigner_converter.go
@@ -17,9 +17,27 @@ type CoSignerConverter struct {
 	Config CoSignerConfig
 }
 
+func (c *CoSignerConverter) GetApprovalCallbackServicePrivateKey() string {
+	//Supports both approvalCallbackServicePrivateKey and bizPrivKey
+	if c.Config.ApprovalCallbackServicePrivateKey == "" {
+		c.Config.ApprovalCallbackServicePrivateKey = c.Config.BizPrivKey
+	}
+	return c.Config.ApprovalCallbackServicePrivateKey
+}
+
+func (c *CoSignerConverter) GetCoSignerPubKey() string {
+	//Supports both coSignerPubKey and apiPublKey
+	if c.Config.CoSignerPubKey == "" {
+		c.Config.CoSignerPubKey = c.Config.ApiPubKey
+	}
+	return c.Config.CoSignerPubKey
+}
+
 type CoSignerConfig struct {
 	CoSignerPubKey                    string `comment:"coSignerPubKey"`
 	ApprovalCallbackServicePrivateKey string `comment:"approvalCallbackServicePrivateKey"`
+	ApiPubKey                         string `comment:"apiPubKey"`
+	BizPrivKey                        string `comment:"bizPrivKey"`
 }
 
 type CoSignerCallBack struct {
@@ -45,16 +63,16 @@ func (c *CoSignerConverter) RequestConvert(d CoSignerCallBack) (string, error) {
 		"bizContent": d.BizContent,
 	}
 	// Verify sign
-	verifyRet := utils.VerifySignWithRSA(serializeParams(responseStringMap), d.Sig, c.Config.CoSignerPubKey)
+	verifyRet := utils.VerifySignWithRSA(serializeParams(responseStringMap), d.Sig, c.GetCoSignerPubKey())
 	if !verifyRet {
 		return "", errors.New("CoSignerCallBack signature verification failed")
 	}
 	// Use your RSA private key to decrypt response's aesKey and aesIv
 	var plaintext []byte
 	if d.RsaType == utils.ECB_OAEP {
-		plaintext, _ = utils.DecryptWithOAEP(d.Key, c.Config.ApprovalCallbackServicePrivateKey)
+		plaintext, _ = utils.DecryptWithOAEP(d.Key, c.GetApprovalCallbackServicePrivateKey())
 	} else {
-		plaintext, _ = utils.DecryptWithRSA(d.Key, c.Config.ApprovalCallbackServicePrivateKey)
+		plaintext, _ = utils.DecryptWithRSA(d.Key, c.GetApprovalCallbackServicePrivateKey())
 	}
 	resAesKey := plaintext[:32]
 	resAesIv := plaintext[32:]
@@ -71,17 +89,39 @@ func (c *CoSignerConverter) RequestConvert(d CoSignerCallBack) (string, error) {
 
 func (c *CoSignerConverter) RequestV3Convert(d CoSignerCallBackV3) (string, error) {
 	responseStringMap := map[string]string{
-		"version":    d.Version,
+		"version":    "v3",
 		"timestamp":  d.Timestamp,
 		"bizContent": d.BizContent,
 	}
 	// Verify sign
-	verifyRet := utils.VerifySignWithRSAPSS(serializeParams(responseStringMap), d.Sig, c.Config.CoSignerPubKey)
+	verifyRet := utils.VerifySignWithRSAPSS(serializeParams(responseStringMap), d.Sig, c.GetCoSignerPubKey())
 	if !verifyRet {
 		return "", errors.New("CoSignerCallBack signature verification failed")
 	}
 	callBackContent, _ := base64.StdEncoding.DecodeString(d.BizContent)
 	return string(callBackContent), nil
+}
+
+func (c *CoSignerConverter) ResponseV3Converter(d any) (map[string]string, error) {
+	// Create params map
+	params := map[string]string{
+		"timestamp": strconv.FormatInt(time.Now().UnixMilli(), 10),
+		"code":      "200",
+		"version":   "v3",
+		"message":   "SUCCESS",
+	}
+	if d != nil {
+		payLoad, _ := json.Marshal(d)
+		params["bizContent"] = base64.StdEncoding.EncodeToString(payLoad)
+	}
+
+	// Sign the request data with your Approval Callback Service's private Key
+	signature, err := utils.SignParamsWithRSAPSS(serializeParams(params), c.GetApprovalCallbackServicePrivateKey())
+	if err != nil {
+		return nil, err
+	}
+	params["sig"] = signature
+	return params, nil
 }
 
 type CoSignerResponse struct {
@@ -118,14 +158,14 @@ func (c *CoSignerConverter) ResponseConverter(d any) (map[string]string, error) 
 	}
 
 	// Use Safeheron RSA public key to encrypt request's aesKey and aesIv
-	encryptedKeyAndIv, err := utils.EncryptWithRSA(append(aesKey, aesIv...), c.Config.CoSignerPubKey)
+	encryptedKeyAndIv, err := utils.EncryptWithRSA(append(aesKey, aesIv...), c.GetCoSignerPubKey())
 	if err != nil {
 		return nil, err
 	}
 	params["key"] = encryptedKeyAndIv
 
 	// Sign the request data with your RSA private key
-	signature, err := utils.SignParamsWithRSA(serializeParams(params), c.Config.ApprovalCallbackServicePrivateKey)
+	signature, err := utils.SignParamsWithRSA(serializeParams(params), c.GetApprovalCallbackServicePrivateKey())
 	if err != nil {
 		return nil, err
 	}
@@ -156,42 +196,20 @@ func (c *CoSignerConverter) ResponseConverterWithNewCryptoType(d any) (map[strin
 	}
 
 	// Use Safeheron RSA public key to encrypt request's aesKey and aesIv
-	encryptedKeyAndIv, err := utils.EncryptWithOAEP(append(aesKey, aesIv...), c.Config.CoSignerPubKey)
+	encryptedKeyAndIv, err := utils.EncryptWithOAEP(append(aesKey, aesIv...), c.GetCoSignerPubKey())
 	if err != nil {
 		return nil, err
 	}
 	params["key"] = encryptedKeyAndIv
 
 	// Sign the request data with your RSA private key
-	signature, err := utils.SignParamsWithRSA(serializeParams(params), c.Config.ApprovalCallbackServicePrivateKey)
+	signature, err := utils.SignParamsWithRSA(serializeParams(params), c.GetApprovalCallbackServicePrivateKey())
 	if err != nil {
 		return nil, err
 	}
 	params["sig"] = signature
 	params["rsaType"] = utils.ECB_OAEP
 	params["aesType"] = utils.GCM
-	return params, nil
-}
-
-func (c *CoSignerConverter) ResponseV3Converter(d any) (map[string]string, error) {
-	// Create params map
-	params := map[string]string{
-		"timestamp": strconv.FormatInt(time.Now().UnixMilli(), 10),
-		"code":      "200",
-		"version":   "v3",
-		"message":   "SUCCESS",
-	}
-	if d != nil {
-		payLoad, _ := json.Marshal(d)
-		params["bizContent"] = base64.StdEncoding.EncodeToString(payLoad)
-	}
-
-	// Sign the request data with your Approval Callback Service's private Key
-	signature, err := utils.SignParamsWithRSAPSS(serializeParams(params), c.Config.ApprovalCallbackServicePrivateKey)
-	if err != nil {
-		return nil, err
-	}
-	params["sig"] = signature
 	return params, nil
 }
 

--- a/safeheron/cosigner/cosigner_converter.go
+++ b/safeheron/cosigner/cosigner_converter.go
@@ -89,6 +89,11 @@ type CoSignerResponse struct {
 	TxKey   string `json:"txKey"`
 }
 
+type CoSignerResponseV3 struct {
+	Action     string `json:"action"`
+	ApprovalId string `json:"approvalId"`
+}
+
 // It has been Deprecated,Please use convertCoSignerResponseWithNewCryptoType
 func (c *CoSignerConverter) ResponseConverter(d any) (map[string]string, error) {
 	// Use AES to encrypt request data
@@ -165,6 +170,28 @@ func (c *CoSignerConverter) ResponseConverterWithNewCryptoType(d any) (map[strin
 	params["sig"] = signature
 	params["rsaType"] = utils.ECB_OAEP
 	params["aesType"] = utils.GCM
+	return params, nil
+}
+
+func (c *CoSignerConverter) ResponseV3Converter(d any) (map[string]string, error) {
+	// Create params map
+	params := map[string]string{
+		"timestamp": strconv.FormatInt(time.Now().UnixMilli(), 10),
+		"code":      "200",
+		"version":   "v3",
+		"message":   "SUCCESS",
+	}
+	if d != nil {
+		payLoad, _ := json.Marshal(d)
+		params["bizContent"] = base64.StdEncoding.EncodeToString(payLoad)
+	}
+
+	// Sign the request data with your RSA private key
+	signature, err := utils.SignParamsWithRSAPSS(serializeParams(params), c.Config.BizPrivKey)
+	if err != nil {
+		return nil, err
+	}
+	params["sig"] = signature
 	return params, nil
 }
 

--- a/safeheron/utils/rsa.go
+++ b/safeheron/utils/rsa.go
@@ -114,6 +114,22 @@ func VerifySignWithRSA(data string, base64Sign string, rasPublicKeyPath string) 
 	return err == nil
 }
 
+func VerifySignWithRSAPSS(data string, base64Sign string, rasPublicKeyPath string) bool {
+	sign, err := base64.StdEncoding.DecodeString(base64Sign)
+	if err != nil {
+		return false
+	}
+
+	publicKey, err := loadPublicKeyFromPath(rasPublicKeyPath)
+	if err != nil {
+		return false
+	}
+
+	hashed := sha256.Sum256([]byte(data))
+	err = rsa.VerifyPSS(publicKey, crypto.SHA256, hashed[:], sign, nil)
+	return err == nil
+}
+
 func loadPublicKeyFromPath(path string) (*rsa.PublicKey, error) {
 	var err error
 	readFile, err := os.ReadFile(path)

--- a/safeheron/utils/rsa.go
+++ b/safeheron/utils/rsa.go
@@ -32,6 +32,24 @@ func SignParamsWithRSA(data string, privateKeyPath string) (string, error) {
 	return b64sig, err
 }
 
+func SignParamsWithRSAPSS(data string, privateKeyPath string) (string, error) {
+	// Sign data with your RSA private key
+	privateKey, err := loadPrivateKeyFromPath(privateKeyPath)
+	if err != nil {
+		return "", err
+	}
+	hashed := sha256.Sum256([]byte(data))
+
+	signature, err := rsa.SignPSS(rand.Reader, privateKey, crypto.SHA256, hashed[:], &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256})
+
+	if err != nil {
+		return "", err
+	}
+	// Encode to base64 format
+	b64sig := base64.StdEncoding.EncodeToString(signature)
+	return b64sig, err
+}
+
 func DecryptWithRSA(base64Data string, privateKeyPath string) ([]byte, error) {
 	privateKey, err := loadPrivateKeyFromPath(privateKeyPath)
 	if err != nil {
@@ -126,7 +144,7 @@ func VerifySignWithRSAPSS(data string, base64Sign string, rasPublicKeyPath strin
 	}
 
 	hashed := sha256.Sum256([]byte(data))
-	err = rsa.VerifyPSS(publicKey, crypto.SHA256, hashed[:], sign, nil)
+	err = rsa.VerifyPSS(publicKey, crypto.SHA256, hashed[:], sign, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: crypto.SHA256})
 	return err == nil
 }
 


### PR DESCRIPTION
v2.1.22

Supports request and response handling methods for [Approval Callback Service v3 version](https://docs.safeheron.vip/api/en.html#Callback%20V3). Refer to:  
- `cosigner.CoSignerConverter.RequestV3Convert`  
- `cosigner.CoSignerConverter.ResponseV3Converter`