### PR TITLE
Add riskType, entity, hopNum, and exposureType fields to RiskDetail in AML Risk Assessment Result

### DIFF
--- a/safeheron/api/tools_api.go
+++ b/safeheron/api/tools_api.go
@@ -44,11 +44,12 @@ type MistTrack struct {
 }
 
 type RiskDetail struct {
-	Type    string `json:"type"`
-	Label   string `json:"label"`
-	Address string `json:"address"`
-	Volume  string `json:"volume"`
-	Percent string `json:"percent"`
+	RiskType     string `json:"riskType"`
+	Entity       string `json:"entity"`
+	HopNum       string `json:"hopNum"`
+	ExposureType string `json:"exposureType"`
+	Volume       string `json:"volume"`
+	Percent      string `json:"percent"`
 }
 
 func (e *ToolsApi) AmlCheckerRetrieves(d AmlCheckerRetrievesRequest, r *AmlCheckerRetrievesResponse) error {


### PR DESCRIPTION
Added four new fields to `safeheron/api.RiskDetail` in the AML risk assessment result:
* riskType
* entity
* hopNum
* exposureType

These fields provide more context in the risk details and are fully backward-compatible.