### PR TITLE
Align SDK fields with API documentation

### DIFF
--- a/safeheron/api/coin_api.go
+++ b/safeheron/api/coin_api.go
@@ -51,17 +51,19 @@ func (e *CoinApi) ListCoinMaintain(r *CoinMaintainResponse) error {
 }
 
 type CheckCoinAddressRequest struct {
-	CoinKey           string `json:"coinKey"`
-	Address           string `json:"address"`
-	CheckContract     bool   `json:"checkContract,omitempty"`
-	CheckAml          bool   `json:"checkAml,omitempty"`
-	CheckAddressValid bool   `json:"checkAddressValid,omitempty"`
+	CoinKey                 string `json:"coinKey"`
+	Address                 string `json:"address"`
+	CheckContract           bool   `json:"checkContract,omitempty"`
+	CheckAml                bool   `json:"checkAml,omitempty"`
+	CheckAddressValid       bool   `json:"checkAddressValid,omitempty"`
+	CheckSolanaOwnerAddress bool   `json:"checkSolanaOwnerAddress,omitempty"`
 }
 
 type CheckCoinAddressResponse struct {
-	Contract     bool `json:"contract"`
-	AmlValid     bool `json:"amlValid"`
-	AddressValid bool `json:"addressValid"`
+	Contract           bool `json:"contract"`
+	AmlValid           bool `json:"amlValid"`
+	AddressValid       bool `json:"addressValid"`
+	SolanaOwnerAddress bool `json:"solanaOwnerAddress"`
 }
 
 func (e *CoinApi) CheckCoinAddress(d CheckCoinAddressRequest, r *CheckCoinAddressResponse) error {

--- a/safeheron/api/mpcsign_api.go
+++ b/safeheron/api/mpcsign_api.go
@@ -10,6 +10,8 @@ type MpcSignApi struct {
 
 type CreateMpcSignRequest struct {
 	CustomerRefId    string `json:"customerRefId,omitempty"`
+	CustomerExt1     string `json:"customerExt1,omitempty"`
+	CustomerExt2     string `json:"customerExt2,omitempty"`
 	SourceAccountKey string `json:"sourceAccountKey,omitempty"`
 	SignAlg          string `json:"signAlg,omitempty"`
 	DataList         []struct {

--- a/safeheron/api/transaction_api.go
+++ b/safeheron/api/transaction_api.go
@@ -145,6 +145,7 @@ type CreateTransactionsRequest struct {
 	Nonce                  int64      `json:"nonce,omitempty"`
 	SequenceNumber         int64      `json:"sequenceNumber,omitempty"`
 	BalanceVerifyType      string     `json:"balanceVerifyType,omitempty"`
+	UtxoSelectionType      string     `json:"utxoSelectionType,omitempty"`
 }
 
 type FeeRateDto struct {
@@ -192,6 +193,7 @@ type CreateTransactionsUTXOMultiDestRequest struct {
 	DestinationTag         string               `json:"destinationTag,omitempty"`
 	IsRbf                  bool                 `json:"isRbf,omitempty"`
 	FailOnAml              *bool                `json:"failOnAml,omitempty"`
+	UtxoSelectionType      string               `json:"utxoSelectionType,omitempty"`
 }
 
 type SourceAddress struct {
@@ -341,6 +343,7 @@ type Member struct {
 	AuditUserName  string `json:"auditUserName"`
 	IsCoSigner     bool   `json:"isCoSigner"`
 	ApprovalStatus string `json:"approvalStatus"`
+	Remark         string `json:"remark"`
 }
 
 func (e *TransactionApi) ApprovalDetailTransactions(d ApprovalDetailTransactionsRequest, r *ApprovalDetailTransactionsResponse) error {
@@ -355,6 +358,7 @@ type TransactionsFeeRateRequest struct {
 	DestinationAddress     string               `json:"destinationAddress"`
 	DestinationAddressList []DestinationAddress `json:"destinationAddressList"`
 	Value                  string               `json:"value,omitempty"`
+	Memo                   string               `json:"memo,omitempty"`
 }
 
 type FeeRate struct {
@@ -365,7 +369,7 @@ type FeeRate struct {
 	MaxPriorityFee string `json:"maxPriorityFee"`
 	MaxFee         string `json:"maxFee"`
 	BytesSize      string `json:"bytesSize"`
-	GasPremium     string `json:"gasPremium "`
+	GasPremium     string `json:"gasPremium"`
 	GasFeeCap      string `json:"gasFeeCap"`
 	GasBudget      string `json:"gasBudget"`
 	GasUnitPrice   string `json:"gasUnitPrice"`

--- a/safeheron/api/web3_api.go
+++ b/safeheron/api/web3_api.go
@@ -19,6 +19,7 @@ type CreateWeb3AccountResponse struct {
 	CustomerRefId string `json:"customerRefId"`
 	AccountName   string `json:"accountName"`
 	HiddenOnUI    bool   `json:"hiddenOnUI"`
+	Archived      bool   `json:"archived"`
 	PubKeyList    []struct {
 		SignAlg string `json:"signAlg"`
 		PubKey  string `json:"pubKey"`
@@ -63,6 +64,8 @@ type ListWeb3AccountRequest struct {
 	FromId        string `json:"fromId,omitempty"`
 	NamePrefix    string `json:"namePrefix,omitempty"`
 	CustomerRefId string `json:"customerRefId,omitempty"`
+	HiddenOnUI    *bool  `json:"hiddenOnUI,omitempty"`
+	Archived      *bool  `json:"archived,omitempty"`
 }
 
 func (e *Web3Api) ListWeb3Accounts(d ListWeb3AccountRequest, r *[]CreateWeb3AccountResponse) error {
@@ -205,7 +208,7 @@ type Web3SignQueryResponse struct {
 		} `json:"sig,omitempty"`
 	} `json:"transaction"`
 	Message struct {
-		ChainId int64  `json:"hash,omitempty"`
+		ChainId int64  `json:"chainId,omitempty"`
 		Data    string `json:"data,omitempty"`
 		Sig     struct {
 			Hash string `json:"hash,omitempty"`
@@ -213,7 +216,7 @@ type Web3SignQueryResponse struct {
 		} `json:"sig,omitempty"`
 	} `json:"message,omitempty"`
 	MessageHash struct {
-		ChainId int64 `json:"hash,omitempty"`
+		ChainId int64 `json:"chainId,omitempty"`
 		SigList []struct {
 			Hash string `json:"hash,omitempty"`
 			Sig  string `json:"sig,omitempty"`

--- a/safeheron/api/whitelist_api.go
+++ b/safeheron/api/whitelist_api.go
@@ -48,6 +48,7 @@ type WhitelistResponse struct {
 	Address         string `json:"address,omitempty"`
 	Memo            string `json:"memo,omitempty"`
 	WhitelistStatus string `json:"whitelistStatus,omitempty"`
+	HiddenOnUI      bool   `json:"hiddenOnUI,omitempty"`
 	CreateTime      int64  `json:"createTime,omitempty"`
 	LastUpdateTime  int64  `json:"lastUpdateTime,omitempty"`
 }
@@ -62,6 +63,7 @@ type ListWhitelistRequest struct {
 	FromId          string `json:"fromId,omitempty"`
 	ChainType       string `json:"chainType,omitempty"`
 	WhitelistStatus string `json:"whitelistStatus,omitempty"`
+	HiddenOnUI      *bool  `json:"hiddenOnUI,omitempty"`
 	CreateTimeMin   int64  `json:"createTimeMin,omitempty"`
 	CreateTimeMax   int64  `json:"createTimeMax,omitempty"`
 }


### PR DESCRIPTION
## What changed

- add documented Solana owner-address validation fields
- add MPC signing customer extension fields
- add transaction UTXO selection, approval remark, and fee-rate memo fields
- add Web3 account visibility/archive fields
- add whitelist visibility fields
- correct the `chainId` and `gasPremium` JSON tags

Deprecated `hashs`, `startTime`, and `endTime` fields are intentionally not reintroduced; callers should continue using `dataList`, `createTimeMin`, and `createTimeMax`.

## Why

The Go SDK models had drifted from the current Safeheron API documentation. Some supported request and response fields were missing, while three JSON tags did not match the documented wire names.

The incorrect tags caused `message.chainId` and `messageHash.chainId` to be represented as `hash`, and `gasPremium` to include a trailing space in its JSON key.

## Impact

SDK callers can use the currently documented fields, optional boolean filters preserve the distinction between omitted and explicit `false`, and Web3/fee-rate responses map to the documented JSON keys.

## Validation

- `go test ./safeheron/...`
- `go vet ./safeheron/...`
- `git diff --check`
- OpenAPI documentation-to-SDK audit: all supported mismatches resolved; 13 remaining documentation rows belong only to intentionally excluded deprecated fields
